### PR TITLE
Add missing dependencies, install to LIBEXECDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,5 +19,5 @@ add_executable(kmozillahelper main.cpp)
 
 target_link_libraries(kmozillahelper KF5::I18n KF5::KIOWidgets KF5::Notifications KF5::WindowSystem)
 
-install(TARGETS kmozillahelper DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/mozilla/)
+install(TARGETS kmozillahelper DESTINATION ${KDE_INSTALL_LIBEXECDIR})
 install(FILES kmozillahelper.notifyrc DESTINATION ${KNOTIFYRC_INSTALL_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,9 @@ include(KDECMakeSettings)
 include(KDECompilerSettings)
 include(FeatureSummary)
 
-find_package(KF5 REQUIRED COMPONENTS Notifications KIO WindowSystem I18n)
+find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets)
+
+find_package(KF5 REQUIRED COMPONENTS Config CoreAddons I18n KIO Notifications Service WindowSystem)
 
 add_executable(kmozillahelper main.cpp)
 


### PR DESCRIPTION
/usr/lib may or may not be a link to lib32/lib64, to me libexecdir seems a better fit.

Adding so far implicit dependencies to cmake.