### PR TITLE
Exclude kmozillahelper from session management (boo#1176852)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -59,6 +59,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 int main(int argc, char* argv[])
 {
+    // Avoid getting started by the session manager
+    qunsetenv("SESSION_MANAGER");
+
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
 
     QApplication app(argc, argv);


### PR DESCRIPTION
Otherwise it might get started again as part of session restoration.